### PR TITLE
Remove core constraint

### DIFF
--- a/flood_control.info.yml
+++ b/flood_control.info.yml
@@ -1,6 +1,5 @@
 name: Flood Control
 type: module
 description: Interface for hidden flood control options.
-core: 8.x
 core_version_requirement: ^8.8 || ^9
 package: Other


### PR DESCRIPTION
To resolve error `The 'core_version_requirement' constraint (^8.8 || ^9) requires the 'core' key not be set in modules/contrib/Flood-Control/flood_control.info.yml`